### PR TITLE
docs(testing): add common assertions & supertest example

### DIFF
--- a/docs/testing-cheatsheet.md
+++ b/docs/testing-cheatsheet.md
@@ -12,3 +12,15 @@ Coverage: npm run test:coverage (thresholds 80/70/50/80)
 Open report: coverage\\lcov-report\\index.html
 
 Debug: In VS Code, use the **Debug Jest Tests** launch to set breakpoints in tests.
+
+Common assertions:
+- expect(x).toBe(y)
+- expect(obj).toEqual({ a:1 })
+- expect(arr).toContain(item)
+- await expect(promise).resolves.toBe(value)
+- await expect(promise).rejects.toThrow()
+
+supertest pattern:
+const res = await request(app).get('/api/health');
+expect(res.status).toBe(200);
+expect(res.body).toEqual({ ok: true });


### PR DESCRIPTION
Expand testing-cheatsheet with practical assertions and a supertest pattern.