### PR TITLE
lint: add Jest globals for test files

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,1 +1,1 @@
-const globals = require('globals'); module.exports = [{ files: ['**/*.js'], languageOptions: { ecmaVersion: 2022, sourceType: 'commonjs', globals: { ...globals.node } }, rules: { 'no-debugger': 'off' } }];
+const globals = require('globals'); module.exports = [{ files: ['**/*.js'], languageOptions: { ecmaVersion: 2022, sourceType: 'commonjs', globals: { ...globals.node } }, rules: { 'no-debugger': 'off' } }, { files: ['src/**/*.test.js','src/**/*.spec.js'], languageOptions: { globals: { ...globals.jest } } }];


### PR DESCRIPTION
Allow describe/it/expect via globals.jest for test files.