### PR TITLE
docs: link to external cheat sheets

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,8 @@ POST /api/echo -> echoes JSON body
 [![Latest release](https://img.shields.io/github/v/release/lizc-au/hello-express?include_prereleases&sort=semver&t=1756832235)](https://github.com/lizc-au/hello-express/releases)
 
 rnrn## Testingrnrn- npm testrn- npm run test:watchrn- npm run test:coveragern- npm run coverage:open
+
+## References
+- Coverage & thresholds: https://github.com/lizc-au/dev-cheatsheets/blob/main/docs/coverage-cheatsheet.md
+- Git PR workflow (protected main): https://github.com/lizc-au/dev-cheatsheets/blob/main/docs/git-pr-workflow.md
+- YAML via Base64 (CRLF + 2/4/6): https://github.com/lizc-au/dev-cheatsheets/blob/main/docs/yaml-base64-template.md


### PR DESCRIPTION
Add links to dev-cheatsheets for coverage, PR workflow, and YAML base64 template.