### PR TITLE
chore: install and configure Jest test tooling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
       "devDependencies": {
         "eslint": "^9.34.0",
         "globals": "^16.3.0",
-        "jest": "^30.1.2",
+        "jest": "^30.1.3",
         "prettier": "^3.6.2",
         "supertest": "^7.1.4"
       }
@@ -940,16 +940,16 @@
       }
     },
     "node_modules/@jest/core": {
-      "version": "30.1.2",
-      "resolved": "https://registry.npmjs.org/@jest/core/-/core-30.1.2.tgz",
-      "integrity": "sha512-iSLOojkYgM7Lw0FF5egecZh+CiLWe4xICM3WOMjFbewhbWn+ixEoPwY7oK9jSCnLLphMFAjussXp7CE3tHa5EA==",
+      "version": "30.1.3",
+      "resolved": "https://registry.npmjs.org/@jest/core/-/core-30.1.3.tgz",
+      "integrity": "sha512-LIQz7NEDDO1+eyOA2ZmkiAyYvZuo6s1UxD/e2IHldR6D7UYogVq3arTmli07MkENLq6/3JEQjp0mA8rrHHJ8KQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/console": "30.1.2",
         "@jest/pattern": "30.0.1",
-        "@jest/reporters": "30.1.2",
-        "@jest/test-result": "30.1.2",
+        "@jest/reporters": "30.1.3",
+        "@jest/test-result": "30.1.3",
         "@jest/transform": "30.1.2",
         "@jest/types": "30.0.5",
         "@types/node": "*",
@@ -959,18 +959,18 @@
         "exit-x": "^0.2.2",
         "graceful-fs": "^4.2.11",
         "jest-changed-files": "30.0.5",
-        "jest-config": "30.1.2",
+        "jest-config": "30.1.3",
         "jest-haste-map": "30.1.0",
         "jest-message-util": "30.1.0",
         "jest-regex-util": "30.0.1",
-        "jest-resolve": "30.1.0",
-        "jest-resolve-dependencies": "30.1.2",
-        "jest-runner": "30.1.2",
-        "jest-runtime": "30.1.2",
+        "jest-resolve": "30.1.3",
+        "jest-resolve-dependencies": "30.1.3",
+        "jest-runner": "30.1.3",
+        "jest-runtime": "30.1.3",
         "jest-snapshot": "30.1.2",
         "jest-util": "30.0.5",
         "jest-validate": "30.1.0",
-        "jest-watcher": "30.1.2",
+        "jest-watcher": "30.1.3",
         "micromatch": "^4.0.8",
         "pretty-format": "30.0.5",
         "slash": "^3.0.0"
@@ -1099,15 +1099,15 @@
       }
     },
     "node_modules/@jest/reporters": {
-      "version": "30.1.2",
-      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-30.1.2.tgz",
-      "integrity": "sha512-8Jd7y3DUFBn8dG/bNJ2blmaJmT2Up74WAXkUJsbL0OuEZHDRRMnS4JmRtLArW2d0H5k8RDdhNN7j70Ki16Zr5g==",
+      "version": "30.1.3",
+      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-30.1.3.tgz",
+      "integrity": "sha512-VWEQmJWfXMOrzdFEOyGjUEOuVXllgZsoPtEHZzfdNz18RmzJ5nlR6kp8hDdY8dDS1yGOXAY7DHT+AOHIPSBV0w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@bcoe/v8-coverage": "^0.2.3",
         "@jest/console": "30.1.2",
-        "@jest/test-result": "30.1.2",
+        "@jest/test-result": "30.1.3",
         "@jest/transform": "30.1.2",
         "@jest/types": "30.0.5",
         "@jridgewell/trace-mapping": "^0.3.25",
@@ -1186,9 +1186,9 @@
       }
     },
     "node_modules/@jest/test-result": {
-      "version": "30.1.2",
-      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-30.1.2.tgz",
-      "integrity": "sha512-mpKFr8DEpfG5aAfQYA5+3KneAsRBXhF7zwtwqT4UeYBckoOPD1MzVxU6gDHwx4gRB7I1MKL6owyJzr8QRq402Q==",
+      "version": "30.1.3",
+      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-30.1.3.tgz",
+      "integrity": "sha512-P9IV8T24D43cNRANPPokn7tZh0FAFnYS2HIfi5vK18CjRkTDR9Y3e1BoEcAJnl4ghZZF4Ecda4M/k41QkvurEQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1202,13 +1202,13 @@
       }
     },
     "node_modules/@jest/test-sequencer": {
-      "version": "30.1.2",
-      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-30.1.2.tgz",
-      "integrity": "sha512-v3vawuj2LC0XjpzF4q0pI0ZlQvMBDNqfRZZ2yHqcsGt7JEYsDK2L1WwrybEGlnOaEvnDFML/Y9xWLiW47Dda8A==",
+      "version": "30.1.3",
+      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-30.1.3.tgz",
+      "integrity": "sha512-82J+hzC0qeQIiiZDThh+YUadvshdBswi5nuyXlEmXzrhw5ZQSRHeQ5LpVMD/xc8B3wPePvs6VMzHnntxL+4E3w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/test-result": "30.1.2",
+        "@jest/test-result": "30.1.3",
         "graceful-fs": "^4.2.11",
         "jest-haste-map": "30.1.0",
         "slash": "^3.0.0"
@@ -1487,9 +1487,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "24.3.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.3.0.tgz",
-      "integrity": "sha512-aPTXCrfwnDLj4VvXrm+UUCQjNEvJgNA8s5F1cvwQU+3KNltTOkBm1j30uNLyqqPNe7gE3KFzImYoZEfLhp4Yow==",
+      "version": "24.3.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.3.1.tgz",
+      "integrity": "sha512-3vXmQDXy+woz+gnrTvuvNrPzekOi+Ds0ReMxw0LzBiK3a+1k0kQn9f2NWk+lgD4rJehFUmYy2gMhJ2ZI+7YP9g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2205,9 +2205,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001739",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001739.tgz",
-      "integrity": "sha512-y+j60d6ulelrNSwpPyrHdl+9mJnQzHBr08xm48Qno0nSk4h3Qojh+ziv2qE6rXf4k3tadF4o1J/1tAbVm1NtnA==",
+      "version": "1.0.30001740",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001740.tgz",
+      "integrity": "sha512-X6I2FZW2KjXKkAgsGgTwRmQXOcN0c7HtPR80KgJVj9LJi29be++fbf7JRPBnNXuzyJEW2ToGIpZ6JZeqqIwO0Q==",
       "dev": true,
       "funding": [
         {
@@ -2520,9 +2520,9 @@
       }
     },
     "node_modules/dedent": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.6.0.tgz",
-      "integrity": "sha512-F1Z+5UCFpmQUzJa11agbyPVMbpgT/qA3/SKyJ1jyBgm7dUcUEa8v9JwDkerSQXfakBwFljIxhOJqGkjUwZ9FSA==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.7.0.tgz",
+      "integrity": "sha512-HGFtf8yhuhGhqO07SV79tRp+br4MnbdjeVxotpn1QBl30pcLLCQjX5b2295ll0fv8RKDKsmWYrl05usHM9CewQ==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
@@ -2631,9 +2631,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.211",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.211.tgz",
-      "integrity": "sha512-IGBvimJkotaLzFnwIVgW9/UD/AOJ2tByUmeOrtqBfACSbAw5b1G0XpvdaieKyc7ULmbwXVx+4e4Be8pOPBrYkw==",
+      "version": "1.5.214",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.214.tgz",
+      "integrity": "sha512-TpvUNdha+X3ybfU78NoQatKvQEm1oq3lf2QbnmCEdw+Bd9RuIAY+hJTvq1avzHM0f7EJfnH3vbCnbzKzisc/9Q==",
       "dev": true,
       "license": "ISC"
     },
@@ -3820,16 +3820,16 @@
       }
     },
     "node_modules/jest": {
-      "version": "30.1.2",
-      "resolved": "https://registry.npmjs.org/jest/-/jest-30.1.2.tgz",
-      "integrity": "sha512-iLreJmUWdANLD2UIbebrXxQqU9jIxv2ahvrBNfff55deL9DtVxm8ZJBLk/kmn0AQ+FyCTrNSlGbMdTgSasldYA==",
+      "version": "30.1.3",
+      "resolved": "https://registry.npmjs.org/jest/-/jest-30.1.3.tgz",
+      "integrity": "sha512-Ry+p2+NLk6u8Agh5yVqELfUJvRfV51hhVBRIB5yZPY7mU0DGBmOuFG5GebZbMbm86cdQNK0fhJuDX8/1YorISQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/core": "30.1.2",
+        "@jest/core": "30.1.3",
         "@jest/types": "30.0.5",
         "import-local": "^3.2.0",
-        "jest-cli": "30.1.2"
+        "jest-cli": "30.1.3"
       },
       "bin": {
         "jest": "bin/jest.js"
@@ -3862,15 +3862,15 @@
       }
     },
     "node_modules/jest-circus": {
-      "version": "30.1.2",
-      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-30.1.2.tgz",
-      "integrity": "sha512-pyqgRv00fPbU3QBjN9I5QRd77eCWA19NA7BLgI1veFvbUIFpeDCKbnG1oyRr6q5/jPEW2zDfqZ/r6fvfE85vrA==",
+      "version": "30.1.3",
+      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-30.1.3.tgz",
+      "integrity": "sha512-Yf3dnhRON2GJT4RYzM89t/EXIWNxKTpWTL9BfF3+geFetWP4XSvJjiU1vrWplOiUkmq8cHLiwuhz+XuUp9DscA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/environment": "30.1.2",
         "@jest/expect": "30.1.2",
-        "@jest/test-result": "30.1.2",
+        "@jest/test-result": "30.1.3",
         "@jest/types": "30.0.5",
         "@types/node": "*",
         "chalk": "^4.1.2",
@@ -3880,7 +3880,7 @@
         "jest-each": "30.1.0",
         "jest-matcher-utils": "30.1.2",
         "jest-message-util": "30.1.0",
-        "jest-runtime": "30.1.2",
+        "jest-runtime": "30.1.3",
         "jest-snapshot": "30.1.2",
         "jest-util": "30.0.5",
         "p-limit": "^3.1.0",
@@ -3894,19 +3894,19 @@
       }
     },
     "node_modules/jest-cli": {
-      "version": "30.1.2",
-      "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-30.1.2.tgz",
-      "integrity": "sha512-Q7H6GGo/0TBB8Mhm3Ab7KKJHn6GeMVff+/8PVCQ7vXXahvr5sRERnNbxuVJAMiVY2JQm5roA7CHYOYlH+gzmUg==",
+      "version": "30.1.3",
+      "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-30.1.3.tgz",
+      "integrity": "sha512-G8E2Ol3OKch1DEeIBl41NP7OiC6LBhfg25Btv+idcusmoUSpqUkbrneMqbW9lVpI/rCKb/uETidb7DNteheuAQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/core": "30.1.2",
-        "@jest/test-result": "30.1.2",
+        "@jest/core": "30.1.3",
+        "@jest/test-result": "30.1.3",
         "@jest/types": "30.0.5",
         "chalk": "^4.1.2",
         "exit-x": "^0.2.2",
         "import-local": "^3.2.0",
-        "jest-config": "30.1.2",
+        "jest-config": "30.1.3",
         "jest-util": "30.0.5",
         "jest-validate": "30.1.0",
         "yargs": "^17.7.2"
@@ -3927,16 +3927,16 @@
       }
     },
     "node_modules/jest-config": {
-      "version": "30.1.2",
-      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-30.1.2.tgz",
-      "integrity": "sha512-gCuBeE/cksjQ3e1a8H4YglZJuVPcnLZQK9jC70E6GbkHNQKPasnOO+r9IYdsUbAekb6c7eVRR8laGLMF06gMqg==",
+      "version": "30.1.3",
+      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-30.1.3.tgz",
+      "integrity": "sha512-M/f7gqdQEPgZNA181Myz+GXCe8jXcJsGjCMXUzRj22FIXsZOyHNte84e0exntOvdPaeh9tA0w+B8qlP2fAezfw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.27.4",
         "@jest/get-type": "30.1.0",
         "@jest/pattern": "30.0.1",
-        "@jest/test-sequencer": "30.1.2",
+        "@jest/test-sequencer": "30.1.3",
         "@jest/types": "30.0.5",
         "babel-jest": "30.1.2",
         "chalk": "^4.1.2",
@@ -3944,12 +3944,12 @@
         "deepmerge": "^4.3.1",
         "glob": "^10.3.10",
         "graceful-fs": "^4.2.11",
-        "jest-circus": "30.1.2",
+        "jest-circus": "30.1.3",
         "jest-docblock": "30.0.1",
         "jest-environment-node": "30.1.2",
         "jest-regex-util": "30.0.1",
-        "jest-resolve": "30.1.0",
-        "jest-runner": "30.1.2",
+        "jest-resolve": "30.1.3",
+        "jest-runner": "30.1.3",
         "jest-util": "30.0.5",
         "jest-validate": "30.1.0",
         "micromatch": "^4.0.8",
@@ -4163,9 +4163,9 @@
       }
     },
     "node_modules/jest-resolve": {
-      "version": "30.1.0",
-      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-30.1.0.tgz",
-      "integrity": "sha512-hASe7D/wRtZw8Cm607NrlF7fi3HWC5wmA5jCVc2QjQAB2pTwP9eVZILGEi6OeSLNUtE1zb04sXRowsdh5CUjwA==",
+      "version": "30.1.3",
+      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-30.1.3.tgz",
+      "integrity": "sha512-DI4PtTqzw9GwELFS41sdMK32Ajp3XZQ8iygeDMWkxlRhm7uUTOFSZFVZABFuxr0jvspn8MAYy54NxZCsuCTSOw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4183,9 +4183,9 @@
       }
     },
     "node_modules/jest-resolve-dependencies": {
-      "version": "30.1.2",
-      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-30.1.2.tgz",
-      "integrity": "sha512-HJjyoaedY4wrwda+eqvgjbwFykrAnQEmhuT0bMyOV3GQIyLPcunZcjfkm77Zr11ujwl34ySdc4qYnm7SG75TjA==",
+      "version": "30.1.3",
+      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-30.1.3.tgz",
+      "integrity": "sha512-DNfq3WGmuRyHRHfEet+Zm3QOmVFtIarUOQHHryKPc0YL9ROfgWZxl4+aZq/VAzok2SS3gZdniP+dO4zgo59hBg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4197,15 +4197,15 @@
       }
     },
     "node_modules/jest-runner": {
-      "version": "30.1.2",
-      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-30.1.2.tgz",
-      "integrity": "sha512-eu9AzpDY/QV+7NuMg6fZMpQ7M24cBkl5dyS1Xj7iwDPDriOmLUXR8rLojESibcIX+sCDTO4KvUeaxWCH1fbTvg==",
+      "version": "30.1.3",
+      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-30.1.3.tgz",
+      "integrity": "sha512-dd1ORcxQraW44Uz029TtXj85W11yvLpDuIzNOlofrC8GN+SgDlgY4BvyxJiVeuabA1t6idjNbX59jLd2oplOGQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/console": "30.1.2",
         "@jest/environment": "30.1.2",
-        "@jest/test-result": "30.1.2",
+        "@jest/test-result": "30.1.3",
         "@jest/transform": "30.1.2",
         "@jest/types": "30.0.5",
         "@types/node": "*",
@@ -4218,10 +4218,10 @@
         "jest-haste-map": "30.1.0",
         "jest-leak-detector": "30.1.0",
         "jest-message-util": "30.1.0",
-        "jest-resolve": "30.1.0",
-        "jest-runtime": "30.1.2",
+        "jest-resolve": "30.1.3",
+        "jest-runtime": "30.1.3",
         "jest-util": "30.0.5",
-        "jest-watcher": "30.1.2",
+        "jest-watcher": "30.1.3",
         "jest-worker": "30.1.0",
         "p-limit": "^3.1.0",
         "source-map-support": "0.5.13"
@@ -4231,9 +4231,9 @@
       }
     },
     "node_modules/jest-runtime": {
-      "version": "30.1.2",
-      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-30.1.2.tgz",
-      "integrity": "sha512-zU02si+lAITgyRmVRgJn/AB4cnakq8+o7bP+5Z+N1A4r2mq40zGbmrg3UpYQWCkeim17tx8w1Tnmt6tQ6y9PGA==",
+      "version": "30.1.3",
+      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-30.1.3.tgz",
+      "integrity": "sha512-WS8xgjuNSphdIGnleQcJ3AKE4tBKOVP+tKhCD0u+Tb2sBmsU8DxfbBpZX7//+XOz81zVs4eFpJQwBNji2Y07DA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4241,7 +4241,7 @@
         "@jest/fake-timers": "30.1.2",
         "@jest/globals": "30.1.2",
         "@jest/source-map": "30.0.1",
-        "@jest/test-result": "30.1.2",
+        "@jest/test-result": "30.1.3",
         "@jest/transform": "30.1.2",
         "@jest/types": "30.0.5",
         "@types/node": "*",
@@ -4254,7 +4254,7 @@
         "jest-message-util": "30.1.0",
         "jest-mock": "30.0.5",
         "jest-regex-util": "30.0.1",
-        "jest-resolve": "30.1.0",
+        "jest-resolve": "30.1.3",
         "jest-snapshot": "30.1.2",
         "jest-util": "30.0.5",
         "slash": "^3.0.0",
@@ -4373,13 +4373,13 @@
       }
     },
     "node_modules/jest-watcher": {
-      "version": "30.1.2",
-      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-30.1.2.tgz",
-      "integrity": "sha512-MtoGuEgqsBM8Jkn52oEj+mXLtF94+njPlHI5ydfduZL5MHrTFr14ZG1CUX1xAbY23dbSZCCEkEPhBM3cQd12Jg==",
+      "version": "30.1.3",
+      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-30.1.3.tgz",
+      "integrity": "sha512-6jQUZCP1BTL2gvG9E4YF06Ytq4yMb4If6YoQGRR6PpjtqOXSP3sKe2kqwB6SQ+H9DezOfZaSLnmka1NtGm3fCQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/test-result": "30.1.2",
+        "@jest/test-result": "30.1.3",
         "@jest/types": "30.0.5",
         "@types/node": "*",
         "ansi-escapes": "^4.3.2",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "devDependencies": {
     "eslint": "^9.34.0",
     "globals": "^16.3.0",
-    "jest": "^30.1.2",
+    "jest": "^30.1.3",
     "prettier": "^3.6.2",
     "supertest": "^7.1.4"
   }


### PR DESCRIPTION
Adds Jest as the testing framework and updates npm scripts for test, watch, coverage, and CI runs.