### PR TITLE
test: add edge-case for /api/echo empty JSON

### DIFF
--- a/src/app.test.js
+++ b/src/app.test.js
@@ -1,1 +1,8 @@
 const request=require('supertest'); const app=require('./app'); describe('API',()=>{ test('GET /api/health', async ()=>{ const res=await request(app).get('/api/health'); expect(res.status).toBe(200); expect(res.body).toEqual({ ok:true }); }); test('POST /api/echo', async ()=>{ const payload={ msg:'Hi Node' }; const res=await request(app).post('/api/echo').send(payload); expect(res.status).toBe(200); expect(res.body).toEqual({ youSent: payload }); }); });
+it('should handle empty JSON on /api/echo', async () => {
+  const res = await request(app)
+    .post('/api/echo')
+    .send({});
+  expect(res.statusCode).toBe(200);
+  expect(res.body).toEqual({ youSent: {} });
+});


### PR DESCRIPTION
Adds a Jest test to verify that /api/echo correctly handles an empty JSON body.
Ensures consistent behavior and improves coverage for edge cases.