### PR TITLE
ci: skip add-to-project for dependabot

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -16,6 +16,7 @@ permissions:
   pull-requests: write
 jobs:
   add-to-project:
+    if: ${{ github.actor != 'dependabot[bot]' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/add-to-project@v1.0.2


### PR DESCRIPTION
Skip add-to-project when actor is dependabot[bot] to prevent failing checks on dependency PRs.