### PR TITLE
ci: use pull_request_target for add-to-project

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -6,7 +6,7 @@ on:
       - reopened
       - transferred
       - labeled
-  pull_request:
+  pull_request_target:
     types:
       - opened
       - reopened


### PR DESCRIPTION
Switch trigger to pull_request_target and keep Dependabot skip to avoid failing checks.