### PR TITLE
ci: run npm run check (format lint tests)

### DIFF
--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -14,4 +14,4 @@ jobs:
           node-version: "22"
           cache: "npm"
       - run: npm ci
-      - run: npm test
+      - run: npm run check

--- a/README.md
+++ b/README.md
@@ -18,6 +18,6 @@ rnrn## Testingrnrn- npm testrn- npm run test:watchrn- npm run test:coveragern- n
 - Coverage & thresholds: https://github.com/lizc-au/dev-cheatsheets/blob/main/docs/coverage-cheatsheet.md
 - Git PR workflow (protected main): https://github.com/lizc-au/dev-cheatsheets/blob/main/docs/git-pr-workflow.md
 - YAML via Base64 (CRLF + 2/4/6): https://github.com/lizc-au/dev-cheatsheets/blob/main/docs/yaml-base64-template.md
- <!-- ruleset-v2 -->
- <!-- ruleset-smoke -->
-rn## Branch rulesrn- Required checks: CodeQL, buildrn- Strict up-to-date: ONrn- Do not require on create: ONrn- Ruleset JSON: [docs/ruleset-main.json](./docs/ruleset-main.json)rn
+   <!-- ruleset-v2 -->
+   <!-- ruleset-smoke -->
+  rn## Branch rulesrn- Required checks: CodeQL, buildrn- Strict up-to-date: ONrn- Do not require on create: ONrn- Ruleset JSON: [docs/ruleset-main.json](./docs/ruleset-main.json)rn

--- a/docs/ruleset-main.json
+++ b/docs/ruleset-main.json
@@ -1,1 +1,49 @@
-{"id":8134420,"name":"Main branch ruleset","target":"branch","source_type":"Repository","source":"lizc-au/hello-express","enforcement":"active","conditions":{"ref_name":{"exclude":[],"include":["~DEFAULT_BRANCH"]}},"rules":[{"type":"deletion"},{"type":"non_fast_forward"},{"type":"pull_request","parameters":{"required_approving_review_count":0,"dismiss_stale_reviews_on_push":true,"require_code_owner_review":false,"require_last_push_approval":false,"required_review_thread_resolution":true,"automatic_copilot_code_review_enabled":false,"allowed_merge_methods":["merge","squash","rebase"]}},{"type":"required_status_checks","parameters":{"strict_required_status_checks_policy":true,"do_not_enforce_on_create":true,"required_status_checks":[{"context":"build","integration_id":15368},{"context":"CodeQL","integration_id":57789}]}}],"node_id":"RRS_lACqUmVwb3NpdG9yec4-hVCJzgB8HxQ","created_at":"2025-09-15T20:26:07.019+08:00","updated_at":"2025-09-15T20:55:42.517+08:00","bypass_actors":[],"current_user_can_bypass":"never","_links":{"self":{"href":"https://api.github.com/repos/lizc-au/hello-express/rulesets/8134420"},"html":{"href":"https://github.com/lizc-au/hello-express/rules/8134420"}}}
+{
+  "id": 8134420,
+  "name": "Main branch ruleset",
+  "target": "branch",
+  "source_type": "Repository",
+  "source": "lizc-au/hello-express",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": { "exclude": [], "include": ["~DEFAULT_BRANCH"] }
+  },
+  "rules": [
+    { "type": "deletion" },
+    { "type": "non_fast_forward" },
+    {
+      "type": "pull_request",
+      "parameters": {
+        "required_approving_review_count": 0,
+        "dismiss_stale_reviews_on_push": true,
+        "require_code_owner_review": false,
+        "require_last_push_approval": false,
+        "required_review_thread_resolution": true,
+        "automatic_copilot_code_review_enabled": false,
+        "allowed_merge_methods": ["merge", "squash", "rebase"]
+      }
+    },
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "strict_required_status_checks_policy": true,
+        "do_not_enforce_on_create": true,
+        "required_status_checks": [
+          { "context": "build", "integration_id": 15368 },
+          { "context": "CodeQL", "integration_id": 57789 }
+        ]
+      }
+    }
+  ],
+  "node_id": "RRS_lACqUmVwb3NpdG9yec4-hVCJzgB8HxQ",
+  "created_at": "2025-09-15T20:26:07.019+08:00",
+  "updated_at": "2025-09-15T20:55:42.517+08:00",
+  "bypass_actors": [],
+  "current_user_can_bypass": "never",
+  "_links": {
+    "self": {
+      "href": "https://api.github.com/repos/lizc-au/hello-express/rulesets/8134420"
+    },
+    "html": { "href": "https://github.com/lizc-au/hello-express/rules/8134420" }
+  }
+}


### PR DESCRIPTION
Updates Node CI to run npm run check on push and pull_request. This runs Prettier check, ESLint, and Jest so CI matches local checks. Risk: low. After merge: delete branch.