### PR TITLE
chore(vscode): align save actions to 'explicit'

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,7 +11,7 @@
   "task.autoDetect": "off",
   "security.workspace.trust.startupPrompt": "never",
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true,
-    "source.organizeImports": true
+    "source.fixAll.eslint": "explicit",
+    "source.organizeImports": "explicit"
   }
 }


### PR DESCRIPTION
Changes:rn- Set editor.codeActionsOnSave to 'explicit' for ESLint and organizeImportsrnrnWhy:rn- Avoid surprise auto-fixes; require deliberate actionsrnrnTest plan:rn- Open in VS Code; save a JS file; no auto-fix unless run explicitlyrn- npm test passes (no app changes)rnrnMerge:rn- Squash-merge after Node CI and CodeQL are green
