### PR TITLE
docs: add markdownlint config (disable MD013)

### DIFF
--- a/.markdownlint.jsonc
+++ b/.markdownlint.jsonc
@@ -1,0 +1,4 @@
+{
+  "default": true,
+  "MD013": false,
+}


### PR DESCRIPTION
Changes:rn- Add .markdownlint.jsonc (MD013 disabled)rnrnWhy:rn- Reduce noise from long lines; keep readability firstrnrnTest plan:rn- Run: npx --yes markdownlint-cli2 "docs/*.md" (should report 0 errors)rn- Node CI unaffectedrnrnMerge:rn- Squash-merge after Node CI and CodeQL are green
