### PR TITLE
docs(README): add repo-purpose note

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 [![Latest release](https://img.shields.io/github/v/release/lizc-au/hello-express?include_prereleases&sort=semver&t=1756832235)](https://github.com/lizc-au/hello-express/releases)
 
+> Minimal Express demo. For a fuller template (more tests, workflows, docs), see **my-node-app**. This repo stays lean on purpose.
+
 **Run:** npm run dev
 
 **Env:** PORT=4000 in .env


### PR DESCRIPTION
Changes:rn- Add repo-purpose note under badges in READMErnrnWhy:rn- Clarifies this is a minimal demo; points to my-node-app for full templaternrnTest plan:rn- Markdownlint passes; no code changesrnrnMerge:rn- Squash-merge after Node CI and CodeQL are green
